### PR TITLE
Support idn as a command line arguments

### DIFF
--- a/digsec/query.py
+++ b/digsec/query.py
@@ -135,6 +135,8 @@ def do_query(argv):
     # ignore last dot
     if qname.endswith('.'):
         qname = qname[:-1]
+    if not qname.isascii():
+        qname = qname.encode("idna").decode()
     default_flags = {'rd': False,
                      'cd': False,
                      'do': False,


### PR DESCRIPTION
It requires python 3.7. 

Also, it also outputs Punycoded names but I think that's expected. Request itself is done with punycoded name...